### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: Build
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/matushorvath/pdp11/security/code-scanning/4](https://github.com/matushorvath/pdp11/security/code-scanning/4)

The best fix is to explicitly add a `permissions:` key with least privilege—set to `contents: read`—at the top level of the workflow file, right after the `name` and before `on:`. This ensures all jobs default to these minimum privileges unless overridden. No additional privileges (like `pull-requests: write`) appear necessary for the given jobs; both simply check out code and run builds.

Specifically:  
- Add the block:
  ```yaml
  permissions:
    contents: read
  ```
  on a new line after `name: Build`.  
- No changes to any job or step are needed, and no additional dependencies or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
